### PR TITLE
Updates to pass distbench unit tests

### DIFF
--- a/homa_client.cc
+++ b/homa_client.cc
@@ -123,11 +123,11 @@ SharedHomaClient::SharedHomaClient()
     vtable.destroy_stream =      destroy_stream;
     vtable.destroy =             destroy;
     vtable.get_endpoint =        get_endpoint;
-    
+
     fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
-	if (fd < 0) {
+    if (fd < 0) {
         gpr_log(GPR_ERROR, "Couldn't open Homa socket: %s", strerror(errno));
-	} else {
+    } else {
         gfd = grpc_fd_create(fd, "homa-socket", true);
         GRPC_CLOSURE_INIT(&readClosure, onRead, this,
                 grpc_schedule_on_exec_ctx);
@@ -166,22 +166,22 @@ grpc_channel *HomaClient::createChannel(const char* target,
     to_add[0].type = GRPC_ARG_STRING;
     to_add[0].key = (char *) GRPC_ARG_DEFAULT_AUTHORITY;
     to_add[0].value.string = (char *) "homa.authority";
-    
+
     grpc_core::UniquePtr<char> canonical_target =
             grpc_core::ResolverRegistry::AddDefaultPrefixIfNeeded(target);
     to_add[1] = grpc_channel_arg_string_create(
             const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());
-    
+
     to_add[2] = grpc_core::ClientChannelFactory::CreateChannelArg(&factory);
-    
+
     const char* to_remove[] = {GRPC_ARG_SERVER_URI, to_add[2].key};
     grpc_channel_args* new_args = grpc_channel_args_copy_and_add_and_remove(
             args, to_remove, 2, to_add, 3);
-    
+
     grpc_channel *channel = grpc_channel_create(target, new_args,
             GRPC_CLIENT_CHANNEL, nullptr, nullptr, 0, nullptr);
     grpc_channel_args_destroy(new_args);
-    
+
     return channel;
 }
 
@@ -214,7 +214,7 @@ std::shared_ptr<grpc::Channel> HomaClient::createInsecureChannel(
  * \param arena
  *      Use this for allocating storage for use by the stream (will
  *      be freed when the stream is destroyed).
- * 
+ *
  * \return
  *      Zero means success, nonzero means failure.
  */
@@ -248,11 +248,11 @@ void SharedHomaClient::set_pollset(grpc_transport* gt, grpc_stream* gs,
 {
     HomaPeer *peer = containerOf(gt, &HomaPeer::transport);
     SharedHomaClient* shc = peer->shc;
-    
+
     if (shc->gfd) {
         grpc_pollset_add_fd(pollset, shc->gfd);
     }
-    
+
 }
 
 /**
@@ -270,12 +270,12 @@ void SharedHomaClient::set_pollset_set(grpc_transport* gt, grpc_stream* gs,
 {
     HomaPeer *peer = containerOf(gt, &HomaPeer::transport);
     SharedHomaClient* shc = peer->shc;
-    
+
     if (shc->gfd) {
         grpc_pollset_set_add_fd(pollset_set, shc->gfd);
     }
     gpr_log(GPR_INFO, "HomaClient::set_pollset_set invoked");
-    
+
 }
 
 /**
@@ -293,7 +293,7 @@ void SharedHomaClient::perform_stream_op(grpc_transport* gt, grpc_stream* gs,
 {
     HomaStream *stream = reinterpret_cast<HomaStream*>(gs);
     grpc_core::MutexLock lock(&stream->mutex);
-    
+
     if (op->send_initial_metadata || op->send_message
             || op->send_trailing_metadata) {
         stream->xmit(op);
@@ -385,7 +385,7 @@ void SharedHomaClient::destroy_stream(grpc_transport* gt, grpc_stream* gs,
     HomaPeer *peer = containerOf(gt, &HomaPeer::transport);
     SharedHomaClient *shc = peer->shc;
     HomaStream *stream = reinterpret_cast<HomaStream*>(gs);
-    
+
     {
         grpc_core::MutexLock lock(&shc->mutex);
         shc->streams.erase(stream->streamId);
@@ -428,13 +428,13 @@ grpc_endpoint* SharedHomaClient::get_endpoint(grpc_transport* gt)
  *      Pointer to the HomaClient structure associated with the socket.
  * \param sockError
  *      Indicates whether the socket has an error condition.
- * 
+ *
  */
 void SharedHomaClient::onRead(void* arg, grpc_error* sockError)
 {
     uint64_t homaId;
     SharedHomaClient *hc = static_cast<SharedHomaClient*>(arg);
-    
+
     if (sockError != GRPC_ERROR_NONE) {
         gpr_log(GPR_INFO, "HomaClient::onRead invoked with error: %s",
                 grpc_error_string(sockError));

--- a/homa_client.cc
+++ b/homa_client.cc
@@ -140,6 +140,7 @@ HomaClient::~HomaClient()
     grpc_fd_shutdown(gfd,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Destroying HomaClient"));
     grpc_fd_orphan(gfd, nullptr, nullptr, "Destroying HomaClient");
+    grpc_core::ExecCtx::Get()->Flush();
 }
 
 /**

--- a/homa_client.cc
+++ b/homa_client.cc
@@ -124,7 +124,7 @@ SharedHomaClient::SharedHomaClient()
     vtable.destroy =             destroy;
     vtable.get_endpoint =        get_endpoint;
 
-    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
+    fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_HOMA);
     if (fd < 0) {
         gpr_log(GPR_ERROR, "Couldn't open Homa socket: %s", strerror(errno));
     } else {

--- a/homa_client.cc
+++ b/homa_client.cc
@@ -137,10 +137,12 @@ SharedHomaClient::SharedHomaClient()
 
 SharedHomaClient::~SharedHomaClient()
 {
-    grpc_fd_shutdown(gfd,
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Destroying HomaClient"));
-    grpc_fd_orphan(gfd, nullptr, nullptr, "Destroying HomaClient");
-    grpc_core::ExecCtx::Get()->Flush();
+    if (gfd) {
+        grpc_fd_shutdown(gfd,
+                GRPC_ERROR_CREATE_FROM_STATIC_STRING("Destroying HomaClient"));
+        grpc_fd_orphan(gfd, nullptr, nullptr, "Destroying HomaClient");
+        grpc_core::ExecCtx::Get()->Flush();
+    }
 }
 
 /**

--- a/homa_client.cc
+++ b/homa_client.cc
@@ -70,7 +70,7 @@ void HomaClient::Connector::Connect(const HomaClient::Connector::Args& args,
         }
         sharedClient->numPeers++;
     }
-    result->transport = &(new HomaClient::Peer(HomaClient::sharedClient,
+    result->transport = &(new HomaClient::HomaPeer(HomaClient::sharedClient,
             *args.address))->transport;
     result->channel_args = grpc_channel_args_copy(args.channel_args);
 
@@ -78,7 +78,7 @@ void HomaClient::Connector::Connect(const HomaClient::Connector::Args& args,
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, notify, GRPC_ERROR_NONE);
 }
 
-HomaClient::Peer::Peer(HomaClient *hc, grpc_resolved_address addr)
+HomaClient::HomaPeer::HomaPeer(HomaClient *hc, grpc_resolved_address addr)
         : transport()
         , hc(hc)
         , addr(addr)
@@ -220,7 +220,7 @@ int HomaClient::init_stream(grpc_transport* gt, grpc_stream* gs,
         grpc_stream_refcount* refcount, const void* server_data,
         grpc_core::Arena* arena)
 {
-    Peer *peer = containerOf(gt, &HomaClient::Peer::transport);
+    HomaPeer *peer = containerOf(gt, &HomaClient::HomaPeer::transport);
     HomaClient* hc = peer->hc;
     HomaStream *stream = reinterpret_cast<HomaStream *>(gs);
     grpc_core::MutexLock lock(&hc->mutex);
@@ -235,7 +235,7 @@ int HomaClient::init_stream(grpc_transport* gt, grpc_stream* gs,
  * Invoked by gRPC to add any file descriptors for a transport to
  * a pollset so that we'll get callbacks when messages arrive.
  * \param gt
- *      Identifies a particular Peer.
+ *      Identifies a particular HomaPeer.
  * \param gs
  *      Info for a particular RPC.
  * \param pollset
@@ -244,7 +244,7 @@ int HomaClient::init_stream(grpc_transport* gt, grpc_stream* gs,
 void HomaClient::set_pollset(grpc_transport* gt, grpc_stream* gs,
         grpc_pollset* pollset)
 {
-    Peer *peer = containerOf(gt, &HomaClient::Peer::transport);
+    HomaPeer *peer = containerOf(gt, &HomaClient::HomaPeer::transport);
     HomaClient* hc = peer->hc;
     
     if (hc->gfd) {
@@ -257,7 +257,7 @@ void HomaClient::set_pollset(grpc_transport* gt, grpc_stream* gs,
  * Invoked by gRPC to add any file descriptors for a transport to
  * a pollset_set so that we'll get callbacks when messages arrive.
  * \param gt
- *      Identifies a particular Peer.
+ *      Identifies a particular HomaPeer.
  * \param gs
  *      Info for a particular RPC.
  * \param pollset_set
@@ -266,7 +266,7 @@ void HomaClient::set_pollset(grpc_transport* gt, grpc_stream* gs,
 void HomaClient::set_pollset_set(grpc_transport* gt, grpc_stream* gs,
         grpc_pollset_set* pollset_set)
 {
-    Peer *peer = containerOf(gt, &HomaClient::Peer::transport);
+    HomaPeer *peer = containerOf(gt, &HomaClient::HomaPeer::transport);
     HomaClient* hc = peer->hc;
     
     if (hc->gfd) {
@@ -313,7 +313,7 @@ void HomaClient::perform_stream_op(grpc_transport* gt, grpc_stream* gs,
 }
 
 /**
- * Invoked by gRPC to perform various operations on a transport (i.e. Peer).
+ * Invoked by gRPC to perform various operations on a transport (i.e. HomaPeer).
  * \param gt
  *      The peer to manipulate.
  * \param op
@@ -371,7 +371,7 @@ void HomaClient::perform_op(grpc_transport* gt, grpc_transport_op* op)
 /**
  * Destructor for Streams.
  * \param gt
- *      Transport (Peer) associated with the stream.
+ *      Transport (HomaPeer) associated with the stream.
  * \param gs
  *      HomaStream to destroy.
  * \param closure
@@ -380,7 +380,7 @@ void HomaClient::perform_op(grpc_transport* gt, grpc_transport_op* op)
 void HomaClient::destroy_stream(grpc_transport* gt, grpc_stream* gs,
         grpc_closure* closure)
 {
-    Peer *peer = containerOf(gt, &HomaClient::Peer::transport);
+    HomaPeer *peer = containerOf(gt, &HomaClient::HomaPeer::transport);
     HomaClient *hc = peer->hc;
     HomaStream *stream = reinterpret_cast<HomaStream*>(gs);
     
@@ -402,7 +402,7 @@ void HomaClient::destroy_stream(grpc_transport* gt, grpc_stream* gs,
  */
 void HomaClient::destroy(grpc_transport* gt)
 {
-    Peer *peer = containerOf(gt, &HomaClient::Peer::transport);
+    HomaPeer *peer = containerOf(gt, &HomaClient::HomaPeer::transport);
     delete peer;
     {
         grpc_core::MutexLock lock(&refCountMutex);

--- a/homa_client.h
+++ b/homa_client.h
@@ -75,7 +75,7 @@ protected:
      * transports for TCP, there's no network connection info here,
      * since Homa is connectionless.
      */
-    struct Peer {
+    struct HomaPeer {
         // Contains a virtual function table for use by the rest of gRPC.
         // gRPC uses this as a transport handle.
         grpc_transport transport;
@@ -86,7 +86,7 @@ protected:
         // Linux struct sockaddr containing the IP address and port of the peer.
         grpc_resolved_address addr;
 
-        Peer(HomaClient *hc, grpc_resolved_address addr);
+        HomaPeer(HomaClient *hc, grpc_resolved_address addr);
     };
 
     static void     destroy(grpc_transport* gt);

--- a/homa_client.h
+++ b/homa_client.h
@@ -53,7 +53,8 @@ protected:
     class SubchannelFactory : public grpc_core::ClientChannelFactory {
     public:
         grpc_core::RefCountedPtr<grpc_core::Subchannel> CreateSubchannel(
-                const grpc_channel_args* args) override;
+            const grpc_resolved_address& address,
+            const grpc_channel_args* args) override;
     };
     
     /**
@@ -85,7 +86,7 @@ protected:
         // Linux struct sockaddr containing the IP address and port of the peer.
         grpc_resolved_address addr;
 
-        Peer(HomaClient *hc, grpc_resolved_address *addr);
+        Peer(HomaClient *hc, grpc_resolved_address addr);
     };
 
     static void     destroy(grpc_transport* gt);

--- a/homa_incoming.cc
+++ b/homa_incoming.cc
@@ -167,7 +167,7 @@ HomaIncoming::UniquePtr HomaIncoming::read(int fd, int flags,
             if (errno == EAGAIN) {
                 return nullptr;
             }
-            gpr_log(GPR_ERROR, "Error in homa_recv (homaId %lu): %s",
+            gpr_log(GPR_DEBUG, "Error in homa_recv (homaId %lu): %s",
                     *homaId, strerror(errno));
             *error = GRPC_OS_ERROR(errno, "homa_recv");
             return nullptr;

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -121,7 +121,7 @@ HomaListener::HomaListener(grpc_server* server, int *port_p)
 
 HomaListener::~HomaListener()
 {
-    std::lock_guard<std::mutex> guard(shared->mutex);
+    grpc_core::MutexLock lock(&shared->mutex);
     shared->ports.erase(transport->port);
     transport->state_tracker.SetState(GRPC_CHANNEL_SHUTDOWN, absl::OkStatus(), "error");
     if (transport->fd >= 0) {
@@ -175,7 +175,7 @@ HomaListener *HomaListener::Get(grpc_server* server, int *port)
     HomaListener *lis = nullptr;
     gpr_once_init(&shared_once, InitShared);
     if (*port) {
-        std::lock_guard<std::mutex> guard(shared->mutex);
+        grpc_core::MutexLock lock(&shared->mutex);
 
         std::unordered_map<int, HomaListener *>::iterator it
                 = shared->ports.find(*port);
@@ -188,7 +188,7 @@ HomaListener *HomaListener::Get(grpc_server* server, int *port)
         return nullptr;
     }
     {
-        std::lock_guard<std::mutex> guard(shared->mutex);
+        grpc_core::MutexLock lock(&shared->mutex);
 
         std::unordered_map<int, HomaListener *>::iterator it
                 = shared->ports.find(*port);

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -96,7 +96,7 @@ HomaListener::HomaListener(grpc_server* server, int *port_p)
     transport->base.vtable = &shared->vtable;
     GRPC_CLOSURE_INIT(&transport->read_closure, transport->onRead, transport,
             grpc_schedule_on_exec_ctx);
-    transport->fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
+    transport->fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_HOMA);
     if (transport->fd < 0) {
         gpr_log(GPR_ERROR, "Couldn't open Homa socket: %s\n", strerror(errno));
         *port_p = 0;

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -24,13 +24,13 @@ int HomaListener::InsecureCredentials::AddPortToServer(const std::string& addr,
 {
     int port;
     char* end;
-    
+
     const char* cursor = addr.c_str();
     if (*cursor == '[') {
-	cursor = strchr(cursor, ']');
+        cursor = strchr(cursor, ']');
     }
     if (cursor != nullptr) {
-	cursor = strchr(cursor, ':');
+        cursor = strchr(cursor, ':');
     }
     if (cursor == nullptr) {
         gpr_log(GPR_ERROR, "bad Homa port specifier '%s', must be 'homa|IP:port'",
@@ -40,7 +40,7 @@ int HomaListener::InsecureCredentials::AddPortToServer(const std::string& addr,
     port = strtol(cursor+1, &end, 10);
     if (*end != '\0') {
         gpr_log(GPR_ERROR,
-		"bad Homa port number '%s', must be between 0 and %d, in decimal",
+                "bad Homa port number '%s', must be between 0 and %d, in decimal",
                 addr.c_str(), HOMA_MIN_DEFAULT_PORT-1);
         return 0;
     }
@@ -63,7 +63,7 @@ int HomaListener::InsecureCredentials::AddPortToServer(const std::string& addr,
  *      Has the syntax "homa:<port>"; indicates the port on which to listen.
  * \param builder
  *      Add the listener to this ServerBuilder.
- * \return 
+ * \return
  */
 std::shared_ptr<grpc::ServerCredentials> HomaListener::insecureCredentials(void)
 {
@@ -78,53 +78,61 @@ std::shared_ptr<grpc::ServerCredentials> HomaListener::insecureCredentials(void)
  * \param port
  *      The Homa port number that this object will manage.
  */
-HomaListener::HomaListener(grpc_server* server, int* port_p)
+HomaListener::HomaListener(grpc_server* server, int *port_p)
     : transport()
-    , server(nullptr)
-    , activeRpcs()
-    , mutex()
-    , fd(-1)
-    , gfd(nullptr)
-    , read_closure()
-    , accept_stream_cb(nullptr)
-    , accept_stream_data(nullptr)
+    , on_destroy_done(nullptr)
 {
+    transport = new HomaTransport{};
+    transport->activeRpcs = {};
+    transport->fd = -1;
+    transport->gfd = nullptr;
+    transport->read_closure = {};
+    transport->accept_stream_cb = nullptr;
+    transport->accept_stream_data = nullptr;
     if (server) {
-        this->server = server->core_server.get();
+        transport->server_ = server->core_server.get();
     }
-    transport.vtable = &shared->vtable;
-    GRPC_CLOSURE_INIT(&read_closure, onRead, this,
+
+    transport->base.vtable = &shared->vtable;
+    GRPC_CLOSURE_INIT(&transport->read_closure, transport->onRead, transport,
             grpc_schedule_on_exec_ctx);
-    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
-    if (fd < 0) {
+    transport->fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
+    if (transport->fd < 0) {
         gpr_log(GPR_ERROR, "Couldn't open Homa socket: %s\n", strerror(errno));
-       *port_p = 0;
-       return;
+        *port_p = 0;
+        return;
     }
-    struct sockaddr_in addr_in{};
+    struct sockaddr_in addr_in;
+    memset(&addr_in, 0, sizeof(addr_in));
     addr_in.sin_family = AF_INET;
     addr_in.sin_port = htons(*port_p);
-    if (bind(fd, (struct sockaddr *) &addr_in,
-               sizeof(addr_in)) != 0) {
-       gpr_log(GPR_ERROR, "Couldn't bind Homa socket to port %d: %s\n", *port_p,
-               strerror(errno));
-       *port_p = 0;
-       return;
+    if (bind(transport->fd, (struct sockaddr *) &addr_in,
+                sizeof(addr_in)) != 0) {
+        gpr_log(GPR_ERROR, "Couldn't bind Homa socket to port %d: %s\n", *port_p,
+                strerror(errno));
+        *port_p = 0;
+        return;
     }
     socklen_t addr_size = sizeof(addr_in);
-    getsockname(fd, reinterpret_cast<sockaddr*>(&addr_in), &addr_size);
+    getsockname(transport->fd, reinterpret_cast<sockaddr*>(&addr_in), &addr_size);
     *port_p = ntohs(addr_in.sin_port);
-    port = *port_p;
+    transport->port = *port_p;
 }
 
 HomaListener::~HomaListener()
 {
     std::lock_guard<std::mutex> guard(shared->mutex);
-    shared->ports.erase(port);
-    if (fd >= 0) {
-        grpc_fd_shutdown(gfd,
+    shared->ports.erase(transport->port);
+    if (transport->fd >= 0) {
+        grpc_fd_shutdown(transport->gfd,
                 GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                 "Homa listener destroyed"));
+        grpc_fd_orphan(transport->gfd, nullptr, nullptr, "goodbye");
+    }
+    grpc_core::ExecCtx::Get()->Flush();
+    if (on_destroy_done) {
+        grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_destroy_done, GRPC_ERROR_NONE);
+        grpc_core::ExecCtx::Get()->Flush();
     }
 }
 
@@ -135,17 +143,17 @@ HomaListener::~HomaListener()
 void HomaListener::InitShared(void)
 {
     shared.emplace();
+    Wire::init();
     shared->vtable.sizeof_stream =       sizeof(HomaStream);
     shared->vtable.name =                "homa_server";
-    shared->vtable.init_stream =         HomaListener::init_stream;
-    shared->vtable.set_pollset =         HomaListener::set_pollset;
-    shared->vtable.set_pollset_set =     HomaListener::set_pollset_set;
-    shared->vtable.perform_stream_op =   HomaListener::perform_stream_op;
-    shared->vtable.perform_op =          HomaListener::perform_op;
-    shared->vtable.destroy_stream =      HomaListener::destroy_stream;
-    shared->vtable.destroy =             HomaListener::destroy;
-    shared->vtable.get_endpoint =        HomaListener::get_endpoint;
-    Wire::init();
+    shared->vtable.init_stream =         HomaTransport::init_stream;
+    shared->vtable.set_pollset =         HomaTransport::set_pollset;
+    shared->vtable.set_pollset_set =     HomaTransport::set_pollset_set;
+    shared->vtable.perform_stream_op =   HomaTransport::perform_stream_op;
+    shared->vtable.perform_op =          HomaTransport::perform_op;
+    shared->vtable.destroy_stream =      HomaTransport::destroy_stream;
+    shared->vtable.destroy =             HomaTransport::destroy;
+    shared->vtable.get_endpoint =        HomaTransport::get_endpoint;
 }
 
 /**
@@ -192,12 +200,13 @@ HomaListener *HomaListener::Get(grpc_server* server, int *port)
 
     char name[30];
     snprintf(name, sizeof(name), "homa-socket:%d", *port);
-    lis->gfd = grpc_fd_create(lis->fd, name, true);
+    lis->transport->gfd = grpc_fd_create(lis->transport->fd, name, true);
     return lis;
 }
 
-void HomaListener::SetOnDestroyDone(grpc_closure* on_destroy_done)
+void HomaListener::SetOnDestroyDone(grpc_closure* on_destroy_done_in)
 {
+    on_destroy_done = on_destroy_done_in;
 }
 
 /**
@@ -208,10 +217,10 @@ void HomaListener::Start(grpc_core::Server* server,
             const std::vector<grpc_pollset*>* pollsets)
 {
     for (size_t i = 0; i < pollsets->size(); i++) {
-        grpc_pollset_add_fd((*pollsets)[i], gfd);
+        grpc_pollset_add_fd((*pollsets)[i], transport->gfd);
     }
-    grpc_fd_notify_on_read(gfd, &read_closure);
-    server->SetupTransport(&transport, NULL, server->channel_args(), nullptr);
+    grpc_fd_notify_on_read(transport->gfd, &transport->read_closure);
+    server->SetupTransport(&transport->base, NULL, server->channel_args(), nullptr);
 }
 
 /**
@@ -226,25 +235,25 @@ void HomaListener::Start(grpc_core::Server* server,
  *      If there was an error creating the stream, then nullptr is returned
  *      and streamLock isn't locked.
  */
-HomaStream *HomaListener::getStream(HomaIncoming *msg,
+HomaStream *HomaListener::HomaTransport::getStream(HomaIncoming *msg,
         std::optional<grpc_core::MutexLock>& streamLock)
 {
     HomaStream *stream;
     grpc_core::MutexLock lock(&mutex);
-    
+
     ActiveIterator it = activeRpcs.find(msg->streamId);
     if (it != activeRpcs.end()) {
         stream = it->second;
         goto done;
     }
-    
+
     // Must create a new HomaStream.
     StreamInit init;
     init.streamId = &msg->streamId;
     init.stream = nullptr;
     if (accept_stream_cb) {
         tt("Calling accept_stream_cb");
-        accept_stream_cb(accept_stream_data, &transport, &init);
+        accept_stream_cb(accept_stream_data, &base, &init);
         tt("accept_stream_cb returned");
     }
     if (init.stream == nullptr) {
@@ -253,10 +262,10 @@ HomaStream *HomaListener::getStream(HomaIncoming *msg,
     }
     stream = init.stream;
     activeRpcs[msg->streamId] = stream;
-        
+
 done:
     streamLock.emplace(&stream->mutex);
-    return stream;    
+    return stream;
 }
 
 /**
@@ -267,30 +276,30 @@ done:
  * \param err
  *      Indicates whether the socket has an error condition.
  */
-void HomaListener::onRead(void* arg, grpc_error* error)
+void HomaListener::HomaTransport::onRead(void* arg, grpc_error* error)
 {
-    HomaListener *lis = static_cast<HomaListener*>(arg);
+    HomaTransport *trans = static_cast<HomaTransport*>(arg);
     uint64_t homaId;
-    
+
     if (error != GRPC_ERROR_NONE) {
-        gpr_log(GPR_ERROR, "OnRead invoked with error: %s",
+        gpr_log(GPR_DEBUG, "OnRead invoked with error: %s",
                 grpc_error_string(error));
         return;
     }
     while (true) {
         std::optional<grpc_core::MutexLock> streamLock;
         grpc_error_handle error;
-        HomaIncoming::UniquePtr msg = HomaIncoming::read(lis->fd,
+        HomaIncoming::UniquePtr msg = HomaIncoming::read(trans->fd,
                 HOMA_RECV_REQUEST|HOMA_RECV_RESPONSE|HOMA_RECV_NONBLOCKING,
                 &homaId, &error);
         if ((error != GRPC_ERROR_NONE) || !msg) {
             break;
         }
 
-        HomaStream *stream = lis->getStream(msg.get(), streamLock);
+        HomaStream *stream = trans->getStream(msg.get(), streamLock);
         stream->handleIncoming(std::move(msg), homaId);
     }
-    grpc_fd_notify_on_read(lis->gfd, &lis->read_closure);
+    grpc_fd_notify_on_read(trans->gfd, &trans->read_closure);
 }
 
 grpc_core::channelz::ListenSocketNode*
@@ -321,33 +330,33 @@ void HomaListener::Orphan()
  * \param arena
  *      Use this for allocating storage for use by the stream (will
  *      be freed when the stream is destroyed).
- * 
+ *
  * \return
  *      Zero means success, nonzero means failure.
  */
-int HomaListener::init_stream(grpc_transport* gt, grpc_stream* gs,
+int HomaListener::HomaTransport::init_stream(grpc_transport* gt, grpc_stream* gs,
         grpc_stream_refcount* refcount, const void* init_info,
         grpc_core::Arena* arena)
 {
-    HomaListener *lis = containerOf(gt, &HomaListener::transport);
+    HomaTransport *trans = containerOf(gt, &HomaTransport::base);
     HomaStream *stream = reinterpret_cast<HomaStream *>(gs);
     StreamInit *init = const_cast<StreamInit*>(
             reinterpret_cast<const StreamInit*>(init_info));
-    new (stream) HomaStream(*init->streamId, lis->fd, refcount, arena);
+    new (stream) HomaStream(*init->streamId, trans->fd, refcount, arena);
     init->stream = stream;
     return 0;
 }
 
-void HomaListener::set_pollset(grpc_transport* gt, grpc_stream* gs,
+void HomaListener::HomaTransport::set_pollset(grpc_transport* gt, grpc_stream* gs,
         grpc_pollset* pollset)
 {
-    gpr_log(GPR_INFO, "HomaListener::set_pollset invoked");
+    gpr_log(GPR_INFO, "HomaTransport::set_pollset invoked");
 }
 
-void HomaListener::set_pollset_set(grpc_transport* gt, grpc_stream* gs,
+void HomaListener::HomaTransport::set_pollset_set(grpc_transport* gt, grpc_stream* gs,
         grpc_pollset_set* pollset_set)
 {
-    gpr_log(GPR_INFO, "HomaListener::set_pollset_set invoked");
+    gpr_log(GPR_INFO, "HomaTransport::set_pollset_set invoked");
 }
 
 /**
@@ -360,14 +369,14 @@ void HomaListener::set_pollset_set(grpc_transport* gt, grpc_stream* gs,
  * \param op
  *      Describes the operation(s) to perform.
  */
-void HomaListener::perform_stream_op(grpc_transport* gt, grpc_stream* gs,
+void HomaListener::HomaTransport::perform_stream_op(grpc_transport* gt, grpc_stream* gs,
         grpc_transport_stream_op_batch* op)
 {
-    HomaListener *lis = containerOf(gt, &HomaListener::transport);
+    HomaTransport *trans = containerOf(gt, &HomaTransport::base);
     HomaStream *stream = reinterpret_cast<HomaStream*>(gs);
     grpc_core::MutexLock lock(&stream->mutex);
     grpc_error_handle error = GRPC_ERROR_NONE;
-    
+
     if (op->cancel_stream) {
         stream->cancelPeer();
         stream->notifyError(op->payload->cancel_stream.cancel_error);
@@ -377,22 +386,24 @@ void HomaListener::perform_stream_op(grpc_transport* gt, grpc_stream* gs,
         stream->saveCallbacks(op);
         stream->transferData();
     }
-    
+
     if (op->send_initial_metadata || op->send_message
             || op->send_trailing_metadata) {
-        if (lis->fd < 0) {
+        if (trans->fd < 0) {
             error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                     "No Homa socket open");
         } else {
             stream->xmit(op);
         }
     }
-    
+
     if (op->on_complete) {
         grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_complete,
                 error);
     }
 }
+
+HomaListener::HomaTransport::HomaTransport() {}
 
 /**
  * Implements transport ops on the overall Homa listener.
@@ -401,80 +412,84 @@ void HomaListener::perform_stream_op(grpc_transport* gt, grpc_stream* gs,
  * \param op
  *      Information about the specific operation(s) to perform
  */
-void HomaListener::perform_op(grpc_transport* gt, grpc_transport_op* op)
+void HomaListener::HomaTransport::perform_op(grpc_transport* gt, grpc_transport_op* op)
 {
-    HomaListener *lis = containerOf(gt, &HomaListener::transport);
+    HomaTransport *trans = containerOf(gt, &HomaTransport::base);
     if (op->start_connectivity_watch) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "start_connectivity_watch");
     }
     if (op->stop_connectivity_watch) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "stop_connectivity_watch");
     }
     if (op->disconnect_with_error != GRPC_ERROR_NONE) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op got "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op got "
                 "disconnect_with_error: %s",
                 grpc_error_string(op->disconnect_with_error));
         GRPC_ERROR_UNREF(op->disconnect_with_error);
     }
     if (op->goaway_error != GRPC_ERROR_NONE) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op got goaway_error: %s",
+        gpr_log(GPR_INFO, "HomaTransport::perform_op got goaway_error: %s",
                 grpc_error_string(op->goaway_error));
         GRPC_ERROR_UNREF(op->goaway_error);
     }
     if (op->set_accept_stream) {
-        lis->accept_stream_cb = op->set_accept_stream_fn;
-        lis->accept_stream_data = op->set_accept_stream_user_data;
+        grpc_core::MutexLock lock(&trans->mutex);
+        trans->accept_stream_cb = op->set_accept_stream_fn;
+        trans->accept_stream_data = op->set_accept_stream_user_data;
     }
     if (op->bind_pollset) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "bind_pollset");
     }
     if (op->bind_pollset_set) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "bind_pollset_set");
     }
     if (op->send_ping.on_initiate) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "send_ping.on_initiate");
     }
     if (op->send_ping.on_ack) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "send_ping.on_ack");
     }
     if (op->reset_connect_backoff) {
-        gpr_log(GPR_INFO, "HomaListener::perform_op invoked with "
+        gpr_log(GPR_INFO, "HomaTransport::perform_op invoked with "
                 "reset_connect_backoff");
     }
 
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
 }
 
-void HomaListener::destroy_stream(grpc_transport* gt, grpc_stream* gs,
+void HomaListener::HomaTransport::destroy_stream(grpc_transport* gt, grpc_stream* gs,
         grpc_closure* closure)
 {
     {
-        HomaListener *lis = containerOf(gt, &HomaListener::transport);
+        HomaTransport *trans = containerOf(gt, &HomaTransport::base);
         HomaStream *stream = reinterpret_cast<HomaStream*>(gs);
-        grpc_core::MutexLock lock(&lis->mutex);
+        grpc_core::MutexLock lock(&trans->mutex);
 
         // This ensures that no-one else is using the stream while we destroy it.
         stream->mutex.Lock();
         stream->mutex.Unlock();
-        lis->activeRpcs.erase(stream->streamId);
+        trans->activeRpcs.erase(stream->streamId);
         stream->~HomaStream();
     }
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
 }
 
-void HomaListener::destroy(grpc_transport* gt)
+void HomaListener::HomaTransport::destroy(grpc_transport* gt)
 {
-    gpr_log(GPR_INFO, "HomaListener::destroy invoked");
+    gpr_log(GPR_INFO, "HomaTransport::destroy invoked");
+    HomaTransport *trans = containerOf(gt, &HomaTransport::base);
+    delete trans;
+    //abort();
 }
 
-grpc_endpoint* HomaListener::get_endpoint(grpc_transport* gt)
+grpc_endpoint* HomaListener::HomaTransport::get_endpoint(grpc_transport* gt)
 {
-    gpr_log(GPR_INFO, "HomaListener::get_endpoint invoked");
+    gpr_log(GPR_INFO, "HomaTransport::get_endpoint invoked");
     return nullptr;
 }

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -124,13 +124,13 @@ HomaListener::~HomaListener()
     grpc_core::MutexLock lock(&shared->mutex);
     shared->ports.erase(transport->port);
     transport->state_tracker.SetState(GRPC_CHANNEL_SHUTDOWN, absl::OkStatus(), "error");
-    if (transport->fd >= 0) {
+    if (transport->gfd) {
         grpc_fd_shutdown(transport->gfd,
                 GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                 "Homa listener destroyed"));
         grpc_fd_orphan(transport->gfd, nullptr, nullptr, "goodbye");
+        grpc_core::ExecCtx::Get()->Flush();
     }
-    grpc_core::ExecCtx::Get()->Flush();
     if (on_destroy_done) {
         grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_destroy_done, GRPC_ERROR_NONE);
         grpc_core::ExecCtx::Get()->Flush();

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -77,7 +77,7 @@ HomaListener::HomaListener(grpc_server* server, int port)
     , accept_stream_data(nullptr)
 {
     if (server) {
-        this->server.reset(server->core_server.get());
+        this->server = server->core_server.get();
     }
     transport.vtable = &vtable;
     vtable.sizeof_stream =       sizeof(HomaStream);

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -80,8 +80,7 @@ std::shared_ptr<grpc::ServerCredentials> HomaListener::insecureCredentials(void)
  */
 HomaListener::HomaListener(grpc_server* server, int port)
     : transport()
-    , vtable()
-    , server()
+    , server(nullptr)
     , activeRpcs()
     , mutex()
     , port(port)
@@ -94,17 +93,7 @@ HomaListener::HomaListener(grpc_server* server, int port)
     if (server) {
         this->server = server->core_server.get();
     }
-    transport.vtable = &vtable;
-    vtable.sizeof_stream =       sizeof(HomaStream);
-    vtable.name =                "homa_server";
-    vtable.init_stream =         init_stream;
-    vtable.set_pollset =         set_pollset;
-    vtable.set_pollset_set =     set_pollset_set;
-    vtable.perform_stream_op =   perform_stream_op;
-    vtable.perform_op =          perform_op;
-    vtable.destroy_stream =      destroy_stream;
-    vtable.destroy =             destroy;
-    vtable.get_endpoint =        get_endpoint;
+    transport.vtable = &shared->vtable;
     GRPC_CLOSURE_INIT(&read_closure, onRead, this,
             grpc_schedule_on_exec_ctx);
 }
@@ -127,6 +116,16 @@ HomaListener::~HomaListener()
 void HomaListener::InitShared(void)
 {
     shared.emplace();
+    shared->vtable.sizeof_stream =       sizeof(HomaStream);
+    shared->vtable.name =                "homa_server";
+    shared->vtable.init_stream =         HomaListener::init_stream;
+    shared->vtable.set_pollset =         HomaListener::set_pollset;
+    shared->vtable.set_pollset_set =     HomaListener::set_pollset_set;
+    shared->vtable.perform_stream_op =   HomaListener::perform_stream_op;
+    shared->vtable.perform_op =          HomaListener::perform_op;
+    shared->vtable.destroy_stream =      HomaListener::destroy_stream;
+    shared->vtable.destroy =             HomaListener::destroy;
+    shared->vtable.get_endpoint =        HomaListener::get_endpoint;
     Wire::init();
 }
 

--- a/homa_listener.cc
+++ b/homa_listener.cc
@@ -12,6 +12,8 @@ gpr_once HomaListener::shared_once = GPR_ONCE_INIT;
  * Adds a Homa listening port to a server.
  * \param addr
  *      Has the syntax "homa:<port>"; indicates the port on which to listen.
+ *      Also accepts "addr:port" for IPv4, but the IP address is ignored.
+ *      Also accepts "[addr]:port" for IPv6, but the IP address is ignored.
  * \param server
  *      Add the listening port to this server.
  * \return
@@ -23,23 +25,36 @@ int HomaListener::InsecureCredentials::AddPortToServer(const std::string& addr,
     int port;
     char* end;
     
-    if (strncmp("homa:", addr.c_str(), 5) != 0) {
-        gpr_log(GPR_ERROR, "bad Homa port specifier '%s', must be 'homa:port'",
+    const char* cursor = addr.c_str();
+    if (*cursor == '[') {
+	cursor = strchr(cursor, ']');
+    }
+    if (cursor != nullptr) {
+	cursor = strchr(cursor, ':');
+    }
+    if (cursor == nullptr) {
+        gpr_log(GPR_ERROR, "bad Homa port specifier '%s', must be 'homa|IP:port'",
                 addr.c_str());
         return 0;
     };
-    port = strtol(addr.c_str()+5, &end, 0);
-    if ((*end != '\0') || (port <= 0)) {
-        gpr_log(GPR_ERROR, "bad Homa port number '%s', must be between 1 and %d",
-                addr.c_str()+5, HOMA_MIN_DEFAULT_PORT-1);
+    port = strtol(cursor+1, &end, 10);
+    if (*end != '\0') {
+        gpr_log(GPR_ERROR,
+		"bad Homa port number '%s', must be between 0 and %d, in decimal",
+                addr.c_str(), HOMA_MIN_DEFAULT_PORT-1);
         return 0;
     }
-    HomaListener *listener = HomaListener::Get(server, port);
+    if (end == cursor+1) {
+        gpr_log(GPR_ERROR, "missing Homa port number '%s'",
+                addr.c_str());
+        return 0;
+    }
+    HomaListener *listener = HomaListener::Get(server, &port);
     if (listener) {
         server->core_server->AddListener(grpc_core::OrphanablePtr
                 <grpc_core::Server::ListenerInterface>(listener));
     }
-    return 1;
+    return port;
 }
 
 /**

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -100,8 +100,8 @@ public:
     // @transport refers to this.
     struct grpc_transport_vtable vtable;
     
-    // Associated gRPC server.
-    grpc_core::OrphanablePtr<grpc_core::Server> server;
+    // Associated gRPC server. Not owned by this object.
+    grpc_core::Server* server;
     
     // Keeps track of all RPCs currently in some stage of processing;
     // used to look up the Stream for an RPC based on its id.

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -114,6 +114,7 @@ protected:
 
         // Used to call us back when fd is readable.
         grpc_closure read_closure;
+        grpc_core::ConnectivityStateTracker state_tracker;
 
         // Associated gRPC server.
         grpc_core::Server *server_;

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -24,7 +24,7 @@ public:
     void Orphan() override ;
     void Start(grpc_core::Server* server,
             const std::vector<grpc_pollset*>* pollsets) override;
-    static HomaListener *Get(grpc_server* server, int port);
+    static HomaListener *Get(grpc_server* server, int* port);
     static std::shared_ptr<grpc::ServerCredentials> insecureCredentials(void);
     void SetOnDestroyDone(grpc_closure* on_destroy_done) override;
     grpc_core::channelz::ListenSocketNode* channelz_listen_socket_node()
@@ -46,7 +46,7 @@ public:
          }
     };
 
-    HomaListener(grpc_server* server, int port);
+    HomaListener(grpc_server* server, int* port);
     HomaStream *    getStream(HomaIncoming *msg,
                             std::optional<grpc_core::MutexLock>& streamLock);
     static void     InitShared(void);

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -136,8 +136,8 @@ protected:
         std::unordered_map<int, HomaListener *> ports;
 
         // Synchronizes access to this structure.
-        std::mutex mutex;
-	//
+        grpc_core::Mutex mutex;
+
 	// @transport refers to this.
 	struct grpc_transport_vtable vtable;
 

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -76,7 +76,10 @@ public:
 
         // Synchronizes access to this structure.
         std::mutex mutex;
-        
+
+        // @transport refers to this.
+        struct grpc_transport_vtable vtable;
+
         Shared() : ports(), mutex() {}
     };
 
@@ -97,9 +100,6 @@ public:
     // as a generic handle for the object.
     grpc_transport transport;
 
-    // @transport refers to this.
-    struct grpc_transport_vtable vtable;
-    
     // Associated gRPC server. Not owned by this object.
     grpc_core::Server* server;
 

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -30,7 +30,7 @@ public:
     grpc_core::channelz::ListenSocketNode* channelz_listen_socket_node()
             const override;
     ~HomaListener();
-    
+
 // protected:
     /**
      * This class provides credentials to create Homa listeners.
@@ -45,8 +45,8 @@ public:
              GPR_ASSERT(0);  // Should not be called on insecure credentials.
          }
     };
-   
-	HomaListener(grpc_server* server, int port);
+
+    HomaListener(grpc_server* server, int port);
     HomaStream *    getStream(HomaIncoming *msg,
                             std::optional<grpc_core::MutexLock>& streamLock);
     static void     InitShared(void);
@@ -91,49 +91,49 @@ public:
         // Used to return the HomaStream address back through callbacks.
         HomaStream *stream;
     };
-    
+
     // Points to a virtual function table for use by the rest of gRPC to
     // treat this object as a transport. gRPC uses a pointer to this field
-    // as a generic handle for the object. 
+    // as a generic handle for the object.
     grpc_transport transport;
-    
+
     // @transport refers to this.
     struct grpc_transport_vtable vtable;
     
     // Associated gRPC server. Not owned by this object.
     grpc_core::Server* server;
-    
+
     // Keeps track of all RPCs currently in some stage of processing;
     // used to look up the Stream for an RPC based on its id.
     std::unordered_map<StreamId, HomaStream*, StreamId::Hasher> activeRpcs;
-    
+
     typedef std::unordered_map<StreamId, HomaStream*,
             StreamId::Hasher>::iterator ActiveIterator;
-    
+
     // Must be held when accessing @activeRpcs. Must not be acquired while
     // holding a stream lock.
     grpc_core::Mutex mutex;
-    
+
     // Homa port number managed by this object.
     int port;
 	
     // File descriptor for a Homa socket; -1 means none.
     int fd;
-    
+
     // Used by grpc to manage the socket in various ways, such as epoll.
     grpc_fd *gfd;
-    
+
     // Used to call us back when fd is readable.
     grpc_closure read_closure;
-    
+
     // Used to notify gRPC of new incoming requests.
     void (*accept_stream_cb)(void* user_data, grpc_transport* transport,
                              const void* server_data);
     void* accept_stream_data;
-    
+
     // Singleton object with common info.
     static std::optional<Shared> shared;
-    
+
     // Used to synchronize initialization of shared.
     static gpr_once shared_once;
 };

--- a/homa_listener.h
+++ b/homa_listener.h
@@ -21,17 +21,10 @@
  */
 class HomaListener : public grpc_core::Server::ListenerInterface {
 public:
-    void Orphan() override ;
-    void Start(grpc_core::Server* server,
-            const std::vector<grpc_pollset*>* pollsets) override;
-    static HomaListener *Get(grpc_server* server, int* port);
+    static HomaListener *Get(grpc_server* server, int *port);
     static std::shared_ptr<grpc::ServerCredentials> insecureCredentials(void);
-    void SetOnDestroyDone(grpc_closure* on_destroy_done) override;
-    grpc_core::channelz::ListenSocketNode* channelz_listen_socket_node()
-            const override;
-    ~HomaListener();
 
-// protected:
+protected:
     /**
      * This class provides credentials to create Homa listeners.
      */
@@ -46,27 +39,94 @@ public:
          }
     };
 
-    HomaListener(grpc_server* server, int* port);
-    HomaStream *    getStream(HomaIncoming *msg,
-                            std::optional<grpc_core::MutexLock>& streamLock);
-    static void     InitShared(void);
-    static void     destroy(grpc_transport* gt);
-    static void     destroy_stream(grpc_transport* gt, grpc_stream* gs,
-                            grpc_closure* then_schedule_closure);
-    static grpc_endpoint*
-                     get_endpoint(grpc_transport* gt);
-    static int      init_stream(grpc_transport* gt, grpc_stream* gs,
-                            grpc_stream_refcount* refcount,
-                            const void* init_info, grpc_core::Arena* arena);
-    static void     onRead(void* arg, grpc_error* error);
-    static void     perform_op(grpc_transport* gt, grpc_transport_op* op);
-    static void     perform_stream_op(grpc_transport* gt, grpc_stream* gs,
-                            grpc_transport_stream_op_batch* op);
-    static void     set_pollset(grpc_transport* gt, grpc_stream* gs,
-                            grpc_pollset* pollset);
-    static void     set_pollset_set(grpc_transport* gt, grpc_stream* gs,
-                            grpc_pollset_set* pollset_set);
-    
+    HomaListener(grpc_server* server, int *port);
+    ~HomaListener();
+    void Orphan() override ;
+    void Start(grpc_core::Server* server,
+            const std::vector<grpc_pollset*>* pollsets) override;
+    grpc_core::channelz::ListenSocketNode* channelz_listen_socket_node()
+            const override;
+    void SetOnDestroyDone(grpc_closure* on_destroy_done) override;
+
+    class HomaTransport {
+    public:
+        HomaTransport();
+        HomaStream *    getStream(HomaIncoming *msg,
+                                std::optional<grpc_core::MutexLock>& streamLock);
+        static void     destroy(grpc_transport* gt);
+        static void     destroy_stream(grpc_transport* gt, grpc_stream* gs,
+                                grpc_closure* then_schedule_closure);
+        static grpc_endpoint*
+                         get_endpoint(grpc_transport* gt);
+        static int      init_stream(grpc_transport* gt, grpc_stream* gs,
+                                grpc_stream_refcount* refcount,
+                                const void* init_info, grpc_core::Arena* arena);
+        static void     onRead(void* arg, grpc_error* error);
+        static void     perform_op(grpc_transport* gt, grpc_transport_op* op);
+        static void     perform_stream_op(grpc_transport* gt, grpc_stream* gs,
+                                grpc_transport_stream_op_batch* op);
+        static void     set_pollset(grpc_transport* gt, grpc_stream* gs,
+                                grpc_pollset* pollset);
+        static void     set_pollset_set(grpc_transport* gt, grpc_stream* gs,
+                                grpc_pollset_set* pollset_set);
+
+        /**
+         * This structure is used to pass data down through callbacks to
+         * init_stream and back up again.
+         */
+        struct StreamInit {
+            // Identifying information from incoming RPC.
+            StreamId *streamId;
+
+            // Used to return the HomaStream address back through callbacks.
+            HomaStream *stream;
+        };
+
+        // Points to a virtual function table for use by the rest of gRPC to
+        // treat this object as a transport. gRPC uses a pointer to this field
+        // as a generic handle for the object.
+        grpc_transport base;
+
+        // Used to notify gRPC of new incoming requests.
+        void (*accept_stream_cb)(void* user_data, grpc_transport* transport,
+                const void* server_data);
+        void* accept_stream_data;
+
+        // Keeps track of all RPCs currently in some stage of processing;
+        // used to look up the Stream for an RPC based on its id.
+        std::unordered_map<StreamId, HomaStream*, StreamId::Hasher> activeRpcs;
+
+        typedef std::unordered_map<StreamId, HomaStream*,
+                StreamId::Hasher>::iterator ActiveIterator;
+
+        // Must be held when accessing @activeRpcs. Must not be acquired while
+        // holding a stream lock.
+        grpc_core::Mutex mutex;
+
+        // Homa port number managed by this object.
+        int port;
+
+        // File descriptor for a Homa socket; -1 means none.
+        int fd;
+
+        // Used by grpc to manage the socket in various ways, such as epoll.
+        grpc_fd *gfd;
+
+        // Used to call us back when fd is readable.
+        grpc_closure read_closure;
+
+        // Associated gRPC server.
+        grpc_core::Server *server_;
+    };
+    // Homa only uses a single socket for incoming requests, but the lifetime
+    // of this socket is still different than the lifetime of the listener,
+    // so they cannot be combined into a single object, or we get use-after-free
+    // errors. The transport object exists to allow the single socket's lifetime
+    // to be managed indepentently.
+    HomaTransport *transport;
+
+    grpc_closure* on_destroy_done;
+
     /**
      * Information that is shared across all HomaListener objects.
      */
@@ -76,66 +136,16 @@ public:
 
         // Synchronizes access to this structure.
         std::mutex mutex;
-
-        // @transport refers to this.
-        struct grpc_transport_vtable vtable;
+	//
+	// @transport refers to this.
+	struct grpc_transport_vtable vtable;
 
         Shared() : ports(), mutex() {}
     };
-
-    /**
-     * This structure is used to pass data down through callbacks to
-     * init_stream and back up again.
-     */
-    struct StreamInit {
-        // Identifying information from incoming RPC.
-        StreamId *streamId;
-
-        // Used to return the HomaStream address back through callbacks.
-        HomaStream *stream;
-    };
-
-    // Points to a virtual function table for use by the rest of gRPC to
-    // treat this object as a transport. gRPC uses a pointer to this field
-    // as a generic handle for the object.
-    grpc_transport transport;
-
-    // Associated gRPC server. Not owned by this object.
-    grpc_core::Server* server;
-
-    // Keeps track of all RPCs currently in some stage of processing;
-    // used to look up the Stream for an RPC based on its id.
-    std::unordered_map<StreamId, HomaStream*, StreamId::Hasher> activeRpcs;
-
-    typedef std::unordered_map<StreamId, HomaStream*,
-            StreamId::Hasher>::iterator ActiveIterator;
-
-    // Must be held when accessing @activeRpcs. Must not be acquired while
-    // holding a stream lock.
-    grpc_core::Mutex mutex;
-
-    // Homa port number managed by this object.
-    int port;
-	
-    // File descriptor for a Homa socket; -1 means none.
-    int fd;
-
-    // Used by grpc to manage the socket in various ways, such as epoll.
-    grpc_fd *gfd;
-
-    // Used to call us back when fd is readable.
-    grpc_closure read_closure;
-
-    // Used to notify gRPC of new incoming requests.
-    void (*accept_stream_cb)(void* user_data, grpc_transport* transport,
-                             const void* server_data);
-    void* accept_stream_data;
-
     // Singleton object with common info.
     static std::optional<Shared> shared;
-
-    // Used to synchronize initialization of shared.
     static gpr_once shared_once;
+    static void     InitShared(void);
 };
 
 #endif // HOMA_LISTENER_H

--- a/homa_stream.cc
+++ b/homa_stream.cc
@@ -564,7 +564,7 @@ messageInserted:
     return;
 
 duplicate:   
-    gpr_log(GPR_INFO, "Dropping duplicate message, stream id %d, sequence %d, "
+    gpr_log(GPR_ERROR, "Dropping duplicate message, stream id %d, sequence %d, "
             "nextIncomingSequence %d, homaId %lu", streamId.id,
             msg->sequence, nextIncomingSequence, homaId);         
 }

--- a/homa_stream.h
+++ b/homa_stream.h
@@ -22,10 +22,10 @@ class HomaStream {
 public:
     // Must be held whenever accessing info in this structure.
     grpc_core::Mutex mutex;
-    
+
     // File descriptor for the Homa socket to use for I/O.
     int fd;
-    
+
     // Uniquely identifies this gRPC RPC, and also provides info about
     // the peer (e.g. for sending responses).
     StreamId streamId;
@@ -43,45 +43,45 @@ public:
 
     // For fast memory allocation.
     grpc_core::Arena* arena;
-    
+
     // Small statically allocated buffer for outgoing messages; holds
     // header plus initial and trailing metadata, if they fit.
     uint8_t xmitBuffer[10000];
-    
+
     // If the metadata didn't completely fit in xmit_msg, extra chunks
     // are allocated dynamically; this vector keeps track of them all
     // so they can be freed.
     std::vector<uint8_t *> xmitOverflows;
-    
+
     // How many bytes to allocate for each element of @xmitOverflows.
     // This is a variable so it can be changed for unit testing.
     size_t overflowChunkSize;
-    
+
     // Contains all of the slices (of message data) referred to by vecs;
     // keeps them alive and stable until the Homa request is sent.
     std::vector<grpc_slice> slices;
-    
+
     // Describes all of the pieces of the current outgoing message.
     std::vector<struct iovec> vecs;
-    
+
     // Additional bytes available immediately following the last element
     // of vecs.
     size_t lastVecAvail;
-    
+
     // Current length of output message, in bytes.
     size_t xmitSize;
-    
+
     // Sequence number to use for the next outgoing message.
     int nextXmitSequence;
-    
+
     // Incoming Homa messages that have not been fully processed.
     // Entries are sorted in increasing order of sequence number.
     std::vector<HomaIncoming::UniquePtr> incoming;
-    
+
     // All incoming Homa messages with sequence numbers less than this one
     // have already been processed.
     int nextIncomingSequence;
-    
+
     // Accumulates slices of incoming message data (potentially from
     // multiple Homa messages) until they can be passed to gRPC.
     grpc_slice_buffer messageData;
@@ -95,25 +95,25 @@ public:
     grpc_closure* messageClosure;
     grpc_metadata_batch* trailMd;
     grpc_closure* trailMdClosure;
-    
+
     // True means we have passed trailing metadata to gRPC, so there is
     // no more message data coming for this stream.
     bool eof;
-    
+
     // True means this RPC has been cancelled, so we shouldn't send
     // any more Homa messages.
     bool cancelled;
-    
+
     // Error that has occurred on this stream, if any.
     grpc_error_handle error;
-    
+
     // Maximum number of bytes to allow in a single Homa message (this
     // is a variable so it can be modified for unit testing).
     size_t maxMessageLength;
 
     HomaStream(StreamId streamId, int fd, grpc_stream_refcount* refcount,
             grpc_core::Arena* arena);
-    
+
     Wire::Header *hdr()
     {
         return reinterpret_cast<Wire::Header*>(xmitBuffer);
@@ -130,7 +130,7 @@ public:
     void    serializeMetadata(grpc_metadata_batch* batch);
     void    transferData();
     void    xmit(grpc_transport_stream_op_batch* op);
-    
+
     static size_t metadataLength(grpc_metadata_batch* batch);
 };
 

--- a/time_trace.h
+++ b/time_trace.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 // Change 1 -> 0 in the following line to disable time tracing globally.
-#define ENABLE_TIME_TRACE 1
+#define ENABLE_TIME_TRACE 0
 
 /**
  * This class implements a circular buffer of entries, each of which

--- a/util.cc
+++ b/util.cc
@@ -35,18 +35,17 @@ void fillData(void *data, int length, int firstValue)
  */
 void logMetadata(const grpc_metadata_batch* mdBatch, const char *info)
 {
-    if (!mdBatch->list.head) {
+    if (mdBatch->empty()) {
         gpr_log(GPR_INFO, "%s: metadata empty", info);
     }
-    for (grpc_linked_mdelem* md = mdBatch->list.head; md != nullptr;
-            md = md->next) {
-        char* key = grpc_slice_to_c_string(GRPC_MDKEY(md->md));
-        char* value = grpc_slice_to_c_string(GRPC_MDVALUE(md->md));
+    mdBatch->ForEach([&](grpc_mdelem& md) {
+        char* key = grpc_slice_to_c_string(GRPC_MDKEY(md));
+        char* value = grpc_slice_to_c_string(GRPC_MDVALUE(md));
         gpr_log(GPR_INFO, "%s: %s: %s (index %d)", info, key, value,
-                GRPC_BATCH_INDEX_OF(GRPC_MDKEY(md->md)));
+                GRPC_BATCH_INDEX_OF(GRPC_MDKEY(md)));
         gpr_free(key);
         gpr_free(value);
-    }
+    });
 }
 
 /**


### PR DESCRIPTION
This is a large refactor of the grpc_homa library to fix various bugs and implement missing features that it needed in order to pass the unit tests for distbench.

It depends on the following kernel changes in HomaModule:
https://github.com/PlatformLab/HomaModule/pull/10

Apologies for the rough nature of these commits. The existing unit tests seem to have missed bugs that were pretty fundamental, so I just kept hacking until all the distbench unit tests passed in ASAN and TSAN modes. By the time all the bugs were understood the changes were too large and intertwined to factor into smaller ones. Several of the individual commits are for ease of review only, they don't actually compile without later commits.

Distbench is built with bazel, so we replaced the Makefile-based build system with a bazel-based one, which will be included in a commit to the distbench repository, not here. I was unable (unmotivated) to get the Makefile to build any code or any of the the grpc_homa unit tests, so I can't be certain that they continue to build and pass, but overall this has to be a big step in the right direction.